### PR TITLE
Expand docs for basic task container testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/.github/workflows/basics.yaml
+++ b/.github/workflows/basics.yaml
@@ -1,0 +1,13 @@
+name: basics
+on: [push, pull_request]
+
+jobs:
+  hello_world:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: docker build -t solana-eval .
+      - name: Run hello-world tests
+        run: docker run --rm -v ${{ github.workspace }}:/workspace solana-eval \
+               ./scripts/test_example.sh basics/hello-world

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Build stage to clone program examples
+FROM rust:1.73-slim AS builder
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev curl git ca-certificates npm && rm -rf /var/lib/apt/lists/*
+
+# Install Solana CLI and Anchor
+RUN curl -sSfL https://release.solana.com/v1.16.17/install | bash -s -- -y
+ENV PATH="/root/.local/share/solana/install/active_release/bin:${PATH}"
+RUN npm install -g @coral-xyz/anchor-cli
+
+WORKDIR /examples
+ARG PROGRAM_EXAMPLES_COMMIT=main
+RUN git clone https://github.com/solana-developers/program-examples.git \
+    && cd program-examples && git checkout $PROGRAM_EXAMPLES_COMMIT
+
+# Final image
+FROM rust:1.73-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev curl git ca-certificates npm && rm -rf /var/lib/apt/lists/*
+RUN curl -sSfL https://release.solana.com/v1.16.17/install | bash -s -- -y
+ENV PATH="/root/.local/share/solana/install/active_release/bin:${PATH}"
+RUN npm install -g @coral-xyz/anchor-cli
+
+WORKDIR /examples/program-examples
+COPY --from=builder /examples/program-examples/basics ./basics
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Evals for testing how good AI agents are at writing code!
 
 Additional documentation is available in `docs/BASICS_TEST_STRUCTURE.md` which
-outlines how to build docker containers and run tests for the Solana program
-examples.
+explains how to build the included Dockerfile, run `scripts/test_example.sh` for
+any of the `/basics` programs from
+`solana-developers/program-examples`, and use the sample GitHub Actions workflow
+under `.github/workflows/basics.yaml`.
 

--- a/docs/BASICS_TEST_STRUCTURE.md
+++ b/docs/BASICS_TEST_STRUCTURE.md
@@ -10,8 +10,24 @@ repository. The focus is on the programs found in the `/basics` directory.
    - Build an image named `solana-eval` that includes the Rust toolchain with
      BPF support, the Solana CLI (including `solana-test-validator`), and the
      `anchor` CLI for Anchor-based examples.
-   - The Dockerfile also clones the `program-examples` repository at a pinned
-     commit so tests do not rely on network access at runtime.
+   - The Dockerfile clones the `program-examples` repository at a pinned commit
+     so tests do not rely on network access at runtime. Only the `/basics`
+     directory is copied into the final image to keep the build lightweight.
+   - The project includes a `Dockerfile` in the repository root that performs
+     these steps. A simplified version looks like:
+
+     ```dockerfile
+     FROM rust:1.73-slim
+     RUN apt-get update && apt-get install -y pkg-config libssl-dev curl git \
+         && curl -sSfL https://release.solana.com/v1.16.17/install | bash -s -- \
+         && npm install -g @coral-xyz/anchor-cli
+     ENV PATH="/root/.local/share/solana/install/active_release/bin:${PATH}"
+     WORKDIR /examples
+     RUN git clone https://github.com/solana-developers/program-examples.git \
+         && cd program-examples && git checkout <pinned-commit>
+     WORKDIR /workspace
+     COPY . .
+     ```
 
 2. **Test scripts**
    - Provide a script `scripts/test_example.sh` that receives the path to an
@@ -26,6 +42,23 @@ repository. The focus is on the programs found in the `/basics` directory.
    - The evaluation harness builds the docker image and runs
      `scripts/test_example.sh <example>` for the target example. All tests must
      pass for a submission to succeed.
+   - A lightweight GitHub Actions workflow can execute a single example under
+     five minutes:
+
+     ```yaml
+     name: basics
+     on: [push, pull_request]
+     jobs:
+       hello_world:
+         runs-on: ubuntu-latest
+         steps:
+           - uses: actions/checkout@v3
+           - name: Build image
+             run: docker build -t solana-eval .
+           - name: Run hello-world tests
+             run: docker run --rm -v ${{ github.workspace }}:/workspace \
+                    solana-eval ./scripts/test_example.sh basics/hello-world
+     ```
 
 ## B. Submission process
 
@@ -66,5 +99,9 @@ that can be turned into code evaluations include:
 
 Each task's tests validate the correct instruction logic by interacting with
 `solana-test-validator` inside the docker container.
+
+Because the examples are pre-built in the image and only the `/basics`
+programs are exercised, a full CI run typically finishes in under five
+minutes on common runners.
 
 

--- a/scripts/test_example.sh
+++ b/scripts/test_example.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <example-path>" >&2
+  exit 1
+fi
+
+EXAMPLE="$1"
+EXAMPLE_DIR="/examples/program-examples/$EXAMPLE"
+
+if [ ! -d "$EXAMPLE_DIR" ]; then
+  echo "Example not found: $EXAMPLE_DIR" >&2
+  exit 1
+fi
+
+cd "$EXAMPLE_DIR"
+
+if [ -f Anchor.toml ]; then
+  anchor test
+else
+  cargo test-bpf
+fi


### PR DESCRIPTION
## Summary
- outline docker image creation using program-examples
- show GitHub Actions snippet for running hello-world tests
- mention basics focus and CI runtime in docs
- add Dockerfile and test script for running examples
- include example workflow and dockerignore

## Testing
- `bash -n scripts/test_example.sh`
- `git status --short`
